### PR TITLE
Aug 655/remove label make responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ npm i -S CINBCUniversal/suprematism-donut-chart
 ```html
 <supre-donut-chart
   [values]="[80]"
-  [outerRadius]="100"
-  [innerRadius]="90"
+  [width]="100px"
+  [height]="90px"
+  [innerWidth]="80%"
 ></supre-donut-chart>
 ```
 
@@ -35,9 +36,9 @@ A component for a donut chart.
 
 #### Inputs
 - `values: Array<number> | number` - The values the donut chart will display. If displaying a percentage, simply pass in the single percent number. This input is mandatory.
-- `outerRadius: number` - The outer radius of the donut chart. This input is mandatory.
-- `innerRadius: number` - The inner radius of the donut chart. This input is mandatory.
-- `text: string` - A value to be displayed. If there is a single number for `values`, that number will be used.
+- `width: string` - The height of the donut chart. Will default to 100% if no value is specified.
+- `height: string` - The width of the donut chart. Will default to 100% if no value is specified.
+- `innerWidth: string` - The width of the donut hole as a percentage.  Will default to 80% if no value is specified
 - `colors: Array<string>` - An array of colors to use for the donut sections. This defaults to `d3.schemeCategory20`. Alternatively, these sections may be styled using the exposed element classes (see below).
 
 #### Hooks

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ npm i -S CINBCUniversal/suprematism-donut-chart
 ```html
 <supre-donut-chart
   [values]="[80]"
-  [width]="100px"
-  [height]="90px"
-  [innerWidth]="80%"
+  [thicknessPct]="20"
 ></supre-donut-chart>
 ```
 
@@ -36,9 +34,7 @@ A component for a donut chart.
 
 #### Inputs
 - `values: Array<number> | number` - The values the donut chart will display. If displaying a percentage, simply pass in the single percent number. This input is mandatory.
-- `width: string` - The height of the donut chart. Will default to 100% if no value is specified.
-- `height: string` - The width of the donut chart. Will default to 100% if no value is specified.
-- `innerWidth: string` - The width of the donut hole as a percentage.  Will default to 80% if no value is specified
+- `thicknessPct: number` - The thickness of the donut as a percentage.  Will default to 20% if no value is specified.
 - `colors: Array<string>` - An array of colors to use for the donut sections. This defaults to `d3.schemeCategory20`. Alternatively, these sections may be styled using the exposed element classes (see below).
 
 #### Hooks

--- a/example/app/app.component.html
+++ b/example/app/app.component.html
@@ -5,12 +5,16 @@
   <label>width:
     <input placeholder="width" [(ngModel)]="width">
   </label>
+  <label>inner width:
+    <input placeholder="inner width" [(ngModel)]="innerWidth">
+  </label>
 </div>
 
 <supre-donut-chart
   [values]="50"
   [height]="height"
   [width]="width"
+  [innerWidth]="innerWidth"
 >
   50%
 </supre-donut-chart>

--- a/example/app/app.component.html
+++ b/example/app/app.component.html
@@ -11,7 +11,9 @@
 ></supre-donut-chart>
 
 <supre-donut-chart
-  [values]="[50]"
+  [values]="50"
   [outerRadius]="25"
   [innerRadius]="22"
-></supre-donut-chart>
+>
+  50
+</supre-donut-chart>

--- a/example/app/app.component.html
+++ b/example/app/app.component.html
@@ -23,7 +23,7 @@
 </supre-donut-chart>
 <supre-donut-chart
     [values]="[30]"
-    [height]="'100%%'"
+    [height]="'100%'"
     [width]="'100%'"
 >
   30%

--- a/example/app/app.component.html
+++ b/example/app/app.component.html
@@ -1,19 +1,30 @@
-<supre-donut-chart
-  [values]="[80]"
-  [outerRadius]="100"
-  [innerRadius]="90"
-></supre-donut-chart>
-
-<supre-donut-chart
-  [values]="[30]"
-  [outerRadius]="10"
-  [innerRadius]="8"
-></supre-donut-chart>
+<div>
+  <label>height:
+    <input placeholder="height" [(ngModel)]="height">
+  </label>
+  <label>width:
+    <input placeholder="width" [(ngModel)]="width">
+  </label>
+</div>
 
 <supre-donut-chart
   [values]="50"
-  [outerRadius]="25"
-  [innerRadius]="22"
+  [height]="height"
+  [width]="width"
 >
-  50
+  50%
+</supre-donut-chart>
+<supre-donut-chart
+    [values]="[80]"
+    [height]="'100px'"
+    [width]="'100px'"
+>
+  80%
+</supre-donut-chart>
+<supre-donut-chart
+    [values]="[30]"
+    [height]="'100%%'"
+    [width]="'100%'"
+>
+  30%
 </supre-donut-chart>

--- a/example/app/app.component.html
+++ b/example/app/app.component.html
@@ -6,29 +6,29 @@
     <input placeholder="width" [(ngModel)]="width">
   </label>
   <label>inner width:
-    <input placeholder="inner width" [(ngModel)]="innerWidth">
+    <input placeholder="inner width" [(ngModel)]="thicknessPct">
   </label>
 </div>
 
 <supre-donut-chart
   [values]="50"
-  [height]="height"
-  [width]="width"
-  [innerWidth]="innerWidth"
+  [style.height]="height"
+  [style.width]="width"
+  [thicknessPct]="thicknessPct"
 >
   50%
 </supre-donut-chart>
 <supre-donut-chart
     [values]="[80]"
-    [height]="'100px'"
-    [width]="'100px'"
+    [style.height]="'100px'"
+    [style.width]="'100px'"
 >
   80%
 </supre-donut-chart>
 <supre-donut-chart
     [values]="[30]"
-    [height]="'100%'"
-    [width]="'100%'"
+    [style.height]="'100%'"
+    [style.width]="'100%'"
 >
   30%
 </supre-donut-chart>

--- a/example/app/app.component.ts
+++ b/example/app/app.component.ts
@@ -8,5 +8,5 @@ export class AppComponent {
   public title = 'app works!';
   public height = '50px';
   public width = '50px';
-  public innerWidth = '80%';
+  public thicknessPct = 20;
 }

--- a/example/app/app.component.ts
+++ b/example/app/app.component.ts
@@ -5,5 +5,7 @@ import { Component } from '@angular/core';
   templateUrl: './app.component.html'
 })
 export class AppComponent {
-  title = 'app works!';
+  public title = 'app works!';
+  public height = '50px';
+  public width = '50px';
 }

--- a/example/app/app.component.ts
+++ b/example/app/app.component.ts
@@ -8,4 +8,5 @@ export class AppComponent {
   public title = 'app works!';
   public height = '50px';
   public width = '50px';
+  public innerWidth = '80%';
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
+    "@types/d3": "^4.9.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "~6.0.60",
     "codelyzer": "~2.0.0",

--- a/src/donut-chart.component.html
+++ b/src/donut-chart.component.html
@@ -1,3 +1,3 @@
 <div class="DonutChart-text">
-  {{text}}
+  <ng-content></ng-content>
 </div>

--- a/src/donut-chart.component.html
+++ b/src/donut-chart.component.html
@@ -1,3 +1,6 @@
+
 <div class="DonutChart-text">
   <ng-content></ng-content>
 </div>
+<svg preserveAspectRatio="xMidYMid meet">
+</svg>

--- a/src/donut-chart.component.html
+++ b/src/donut-chart.component.html
@@ -1,4 +1,3 @@
-
 <div class="DonutChart-text">
   <ng-content></ng-content>
 </div>

--- a/src/donut-chart.component.scss
+++ b/src/donut-chart.component.scss
@@ -1,18 +1,19 @@
-/deep/ .DonutChart {
+:host {
   display: block;
   position: relative;
-}
-.DonutChart-text {
-  height: 100%;
-  position: absolute;
-  display: flex;
-  width: 100%;
-  justify-content: center;
-  align-items: center;
-}
 
-svg {
-  height: 100%;
-  width: 100%;
-  transform-origin: center;
+  .DonutChart-text {
+    height: 100%;
+    position: absolute;
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+  }
+
+  svg {
+    height: 100%;
+    width: 100%;
+    transform-origin: center;
+  }
 }

--- a/src/donut-chart.component.scss
+++ b/src/donut-chart.component.scss
@@ -10,3 +10,9 @@
   justify-content: center;
   align-items: center;
 }
+
+svg {
+  height: 100%;
+  width: 100%;
+  transform-origin: center;
+}

--- a/src/donut-chart.component.spec.ts
+++ b/src/donut-chart.component.spec.ts
@@ -25,10 +25,10 @@ describe('Donut Chart', () => {
     it(
       'should be text if provided',
       async(() => {
-          const innerHTML = fixture.debugElement
-            .query(By.css('.DonutChart-text'))
-            .nativeElement.innerHTML.trim();
-          expect(innerHTML).toEqual('33');
+        const innerHTML = fixture.debugElement
+          .query(By.css('.DonutChart-text'))
+          .nativeElement.innerHTML.trim();
+        expect(innerHTML).toEqual('33');
       })
     );
   });

--- a/src/donut-chart.component.spec.ts
+++ b/src/donut-chart.component.spec.ts
@@ -66,19 +66,19 @@ describe('Donut Chart', () => {
   });
   describe('donut thickness', () => {
     it(
-      'should correspond to inner width',
+      'should correspond to thicknessPct',
       async(() => {
         componentInstance.values = 80;
-        componentInstance.innerWidth = '80%';
+        componentInstance.thicknessPct = 20;
         fixture.detectChanges();
         fixture.whenStable().then(() => {
           const svg = fixture.nativeElement.querySelector(
             '.DonutChart-section.DonutChart-section--0'
           ) as HTMLElement;
           expect(svg.getAttribute('d')).toBe(
-            'M5.51091059616309e-16,-9A9,9,0,1,1,-8.559508646656383,' +
-              '-2.7811529493745257L-6.847606917325106,-2.2249223594' +
-              '996206A7.2,7.2,0,1,0,4.4087284769304716e-16,-7.2Z'
+            'M3.061616997868383e-15,-50A50,50,0,1,1,-47.55282581475768,' +
+              '-15.450849718747364L-38.042260651806146,-12.3606797' +
+              '74997891A40,40,0,1,0,2.4492935982947065e-15,-40Z'
           );
         });
       })
@@ -93,9 +93,9 @@ describe('Donut Chart', () => {
   selector: 'supre-test-comp',
   template: `
     <supre-donut-chart [values]="values"
-                       [width]="width"
-                       [height]="height"
-                       [innerWidth]="innerWidth">
+                       [style.width]="width"
+                       [style.height]="height"
+                       [thicknessPct]="thicknessPct">
       33
     </supre-donut-chart>
   `
@@ -104,5 +104,5 @@ class TestComponent {
   values: number | Array<number>;
   width: string;
   height: string;
-  innerWidth: string;
+  thicknessPct: number;
 }

--- a/src/donut-chart.component.spec.ts
+++ b/src/donut-chart.component.spec.ts
@@ -37,8 +37,6 @@ describe('Donut Chart', () => {
       'should be the input if array and more than two values',
       async(() => {
         componentInstance.values = [80, 90];
-        componentInstance.outerRadius = 100;
-        componentInstance.innerRadius = 96;
         fixture.detectChanges();
         fixture.whenStable().then(() => {
           expect(componentInstance.values).toEqual([80, 90]);
@@ -49,8 +47,6 @@ describe('Donut Chart', () => {
       'should be array of value and offset in single value array ',
       async(() => {
         componentInstance.values = [80];
-        componentInstance.outerRadius = 100;
-        componentInstance.innerRadius = 96;
 
         fixture.whenStable().then(() => {
           expect(componentInstance.values).toEqual([80]);
@@ -61,11 +57,29 @@ describe('Donut Chart', () => {
       'should be array of value and offset in single number ',
       async(() => {
         componentInstance.values = 80;
-        componentInstance.outerRadius = 100;
-        componentInstance.innerRadius = 96;
 
         fixture.whenStable().then(() => {
           expect(componentInstance.values).toEqual(80);
+        });
+      })
+    );
+  });
+  describe('donut thickness', () => {
+    it(
+      'should correspond to inner width',
+      async(() => {
+        componentInstance.values = 80;
+        componentInstance.innerWidth = '80%';
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          const svg = fixture.nativeElement.querySelector(
+            '.DonutChart-section.DonutChart-section--0'
+          ) as HTMLElement;
+          expect(svg.getAttribute('d')).toBe(
+            'M5.51091059616309e-16,-9A9,9,0,1,1,-8.559508646656383,' +
+              '-2.7811529493745257L-6.847606917325106,-2.2249223594' +
+              '996206A7.2,7.2,0,1,0,4.4087284769304716e-16,-7.2Z'
+          );
         });
       })
     );
@@ -79,14 +93,16 @@ describe('Donut Chart', () => {
   selector: 'supre-test-comp',
   template: `
     <supre-donut-chart [values]="values"
-                       [outerRadius]="outerRadius"
-                       [innerRadius]="innerRadius">
+                       [width]="width"
+                       [height]="height"
+                       [innerWidth]="innerWidth">
       33
     </supre-donut-chart>
   `
 })
 class TestComponent {
   values: number | Array<number>;
-  outerRadius: number;
-  innerRadius: number;
+  width: string;
+  height: string;
+  innerWidth: string;
 }

--- a/src/donut-chart.component.spec.ts
+++ b/src/donut-chart.component.spec.ts
@@ -1,18 +1,19 @@
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { DonutChartComponent } from './donut-chart.component';
 import { DonutChartModule } from './index';
+import { Component } from '@angular/core';
 
 describe('Donut Chart', () => {
-  let fixture: ComponentFixture<DonutChartComponent>;
-  let componentInstance: DonutChartComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let componentInstance: TestComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [DonutChartModule]
+      imports: [DonutChartModule],
+      declarations: [TestComponent]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(DonutChartComponent);
+    fixture = TestBed.createComponent(TestComponent);
     componentInstance = fixture.debugElement.componentInstance;
   });
 
@@ -20,60 +21,14 @@ describe('Donut Chart', () => {
     expect(componentInstance).toBeTruthy();
   });
 
-  describe('donut text', () => {
+  describe('donut content', () => {
     it(
-      'should be the input if provided',
+      'should be text if provided',
       async(() => {
-        componentInstance.values = [80];
-        componentInstance.outerRadius = 100;
-        componentInstance.innerRadius = 96;
-        componentInstance.text = 'foo';
-
-        fixture.whenStable().then(() => {
-          componentInstance.ngOnChanges();
-          fixture.detectChanges();
-          expect(componentInstance.text).toEqual('foo');
           const innerHTML = fixture.debugElement
             .query(By.css('.DonutChart-text'))
             .nativeElement.innerHTML.trim();
-          expect(innerHTML).toEqual('foo');
-        });
-      })
-    );
-    it(
-      'should be the single value if only one value and no text input',
-      async(() => {
-        componentInstance.values = [80];
-        componentInstance.outerRadius = 100;
-        componentInstance.innerRadius = 96;
-
-        fixture.whenStable().then(() => {
-          componentInstance.ngOnChanges();
-          fixture.detectChanges();
-          expect(componentInstance.text).toEqual('80%');
-          const innerHTML = fixture.debugElement
-            .query(By.css('.DonutChart-text'))
-            .nativeElement.innerHTML.trim();
-          expect(innerHTML).toEqual('80%');
-        });
-      })
-    );
-    it(
-      'should be the nothing if more than one value and no text input',
-      async(() => {
-        componentInstance.values = [80, 20];
-        componentInstance.outerRadius = 100;
-        componentInstance.innerRadius = 96;
-
-        fixture.whenStable().then(() => {
-          componentInstance.ngOnChanges();
-          fixture.detectChanges();
-          expect(componentInstance.text).toBeFalsy();
-          const innerHTML = fixture.debugElement
-            .query(By.css('.DonutChart-text'))
-            .nativeElement.innerHTML.trim();
-          expect(innerHTML).toEqual('');
-        });
+          expect(innerHTML).toEqual('33');
       })
     );
   });
@@ -84,9 +39,8 @@ describe('Donut Chart', () => {
         componentInstance.values = [80, 90];
         componentInstance.outerRadius = 100;
         componentInstance.innerRadius = 96;
-
+        fixture.detectChanges();
         fixture.whenStable().then(() => {
-          componentInstance.ngOnChanges();
           expect(componentInstance.values).toEqual([80, 90]);
         });
       })
@@ -99,8 +53,7 @@ describe('Donut Chart', () => {
         componentInstance.innerRadius = 96;
 
         fixture.whenStable().then(() => {
-          componentInstance.ngOnChanges();
-          expect(componentInstance.values).toEqual([80, 20]);
+          expect(componentInstance.values).toEqual([80]);
         });
       })
     );
@@ -112,10 +65,28 @@ describe('Donut Chart', () => {
         componentInstance.innerRadius = 96;
 
         fixture.whenStable().then(() => {
-          componentInstance.ngOnChanges();
-          expect(componentInstance.values).toEqual([80, 20]);
+          expect(componentInstance.values).toEqual(80);
         });
       })
     );
   });
 });
+
+/**
+ * Test component that contains a donut chart.
+ */
+@Component({
+  selector: 'supre-test-comp',
+  template: `
+    <supre-donut-chart [values]="buttonValues"
+                       [outerRadius]="buttonOuterRadius"
+                       [innerRadius]="buttonInnerRadius">
+      33
+    </supre-donut-chart>
+  `
+})
+class TestComponent {
+  values: number | Array<number>;
+  outerRadius: number;
+  innerRadius: number;
+}

--- a/src/donut-chart.component.spec.ts
+++ b/src/donut-chart.component.spec.ts
@@ -78,9 +78,9 @@ describe('Donut Chart', () => {
 @Component({
   selector: 'supre-test-comp',
   template: `
-    <supre-donut-chart [values]="buttonValues"
-                       [outerRadius]="buttonOuterRadius"
-                       [innerRadius]="buttonInnerRadius">
+    <supre-donut-chart [values]="values"
+                       [outerRadius]="outerRadius"
+                       [innerRadius]="innerRadius">
       33
     </supre-donut-chart>
   `

--- a/src/donut-chart.component.ts
+++ b/src/donut-chart.component.ts
@@ -16,8 +16,7 @@ import { Pie } from 'd3-shape';
   styleUrls: ['./donut-chart.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DonutChartComponent
-  implements OnInit, OnChanges {
+export class DonutChartComponent implements OnInit, OnChanges {
   private static readonly outerRadius = 50;
   private vals: Array<number>;
   private thickness: number;

--- a/src/donut-chart.component.ts
+++ b/src/donut-chart.component.ts
@@ -52,7 +52,7 @@ export class DonutChartComponent
    */
   @Input()
   get innerWidth(): string {
-    return this.innerWd ? this.innerWidth : '80%';
+    return this.innerWd ? this.innerWd : '80%';
   }
   set innerWidth(innerWd: string) {
     this.innerWd = innerWd;
@@ -94,9 +94,6 @@ export class DonutChartComponent
 
   ngOnChanges() {
     this.calculateDimensions();
-    if (!this.innerWidth) {
-      this.innerWidth = '80';
-    }
     this.innerRadius = this.outerRadius * (parseFloat(this.innerWidth) / 100);
     this.clearChart();
     this.createDonutChart();

--- a/src/donut-chart.component.ts
+++ b/src/donut-chart.component.ts
@@ -1,5 +1,12 @@
 import {
-  Component, Input, ElementRef, OnChanges, ChangeDetectionStrategy, OnInit, HostBinding, AfterViewChecked, AfterViewInit
+  Component,
+  Input,
+  ElementRef,
+  OnChanges,
+  ChangeDetectionStrategy,
+  OnInit,
+  HostBinding,
+  AfterViewChecked
 } from '@angular/core';
 import * as d3 from 'd3';
 import { Pie } from 'd3-shape';
@@ -10,7 +17,8 @@ import { Pie } from 'd3-shape';
   styleUrls: ['./donut-chart.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DonutChartComponent implements OnInit, OnChanges, AfterViewChecked {
+export class DonutChartComponent
+  implements OnInit, OnChanges, AfterViewChecked {
   private vals: Array<number>;
   private chart;
   private calculatedHeight: number;
@@ -21,7 +29,7 @@ export class DonutChartComponent implements OnInit, OnChanges, AfterViewChecked 
   @Input()
   get values(): Array<number> | number {
     return this.vals;
-  };
+  }
   set values(vals: Array<number> | number) {
     if (Array.isArray(vals)) {
       this.vals = vals;
@@ -74,18 +82,20 @@ export class DonutChartComponent implements OnInit, OnChanges, AfterViewChecked 
 
   ngOnChanges() {
     this.calculateDimensions();
-    this.innerRadius = (this.outerRadius / 5) * 4;
+    this.innerRadius = this.outerRadius / 5 * 4;
   }
 
   ngAfterViewChecked() {
     this.calculateDimensions();
-    this.elementRef.nativeElement.style.fontSize = `${this.outerRadius / 1.5}px`;
+    this.elementRef.nativeElement.style.fontSize = `${this.outerRadius /
+      1.5}px`;
   }
 
   private calculateDimensions() {
     this.calculatedHeight = this.elementRef.nativeElement.getBoundingClientRect().height;
     this.calculatedWidth = this.elementRef.nativeElement.getBoundingClientRect().width;
-    this.outerRadius = Math.min(this.calculatedWidth, this.calculatedHeight) / 2;
+    this.outerRadius =
+      Math.min(this.calculatedWidth, this.calculatedHeight) / 2;
   }
 
   createDonutChart() {

--- a/src/donut-chart.component.ts
+++ b/src/donut-chart.component.ts
@@ -26,6 +26,7 @@ export class DonutChartComponent
   private wd: string;
   private outerRadius: number;
   private innerRadius: number;
+  private innerWd: string;
 
   @Input()
   get values(): Array<number> | number {
@@ -45,7 +46,17 @@ export class DonutChartComponent
   }
 
   @Input() colors: Array<string> = d3.schemeCategory20;
-  @Input() innerWidth: string;
+
+  /**
+   * The width of the donut hole.  Defaults to 80% if no value is specified.
+   */
+  @Input()
+  get innerWidth(): string {
+    return this.innerWd ? this.innerWidth : '80%';
+  }
+  set innerWidth(innerWd: string) {
+    this.innerWd = innerWd;
+  }
 
   /**
    * Height of the component in px or %.  Defaults to 100% if no height is specified.

--- a/src/donut-chart.component.ts
+++ b/src/donut-chart.component.ts
@@ -1,31 +1,38 @@
-import { Component, Input, ElementRef, OnChanges } from '@angular/core';
+import { Component, Input, ElementRef, OnChanges, ChangeDetectionStrategy } from '@angular/core';
 import * as d3 from 'd3';
+import { Pie } from 'd3-shape';
 
 @Component({
   selector: 'supre-donut-chart',
   templateUrl: './donut-chart.component.html',
-  styleUrls: ['./donut-chart.component.scss']
+  styleUrls: ['./donut-chart.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DonutChartComponent implements OnChanges {
-  @Input() values: Array<number> | number;
+  private vals: Array<number>;
+  @Input()
+  get values(): Array<number> | number {
+    return this.vals;
+  };
+  set values(vals: Array<number> | number) {
+    if (Array.isArray(vals)) {
+      this.vals = vals;
+    } else {
+      this.vals = [vals];
+    }
+
+    if (this.vals.length === 1) {
+      const value = this.vals[0];
+      this.vals = this.vals.concat(100 - value);
+    }
+  }
   @Input() outerRadius: number;
   @Input() innerRadius: number;
-  @Input() text: string;
   @Input() colors: Array<string> = d3.schemeCategory20;
 
   constructor(private elementRef: ElementRef) {}
 
   ngOnChanges() {
-    if (!Array.isArray(this.values)) {
-      this.values = [this.values];
-    }
-    if (this.values.length === 1) {
-      const value = this.values[0];
-      if (!this.text) {
-        this.text = `${value}%`;
-      }
-      this.values = this.values.concat(100 - value);
-    }
     this.elementRef.nativeElement.style.width = `${this.outerRadius * 2}px`;
     this.elementRef.nativeElement.style.height = `${this.outerRadius * 2}px`;
     this.elementRef.nativeElement.style.fontSize = `${this.outerRadius /
@@ -35,9 +42,9 @@ export class DonutChartComponent implements OnChanges {
   }
 
   createDonutChart() {
-    const pie = d3.pie().sort(null);
+    const pie: Pie<any, number | { valueOf(): number }> = d3.pie().sort(null);
 
-    const arc = d3
+    const arc: any = d3
       .arc()
       .innerRadius(this.innerRadius)
       .outerRadius(this.outerRadius);
@@ -52,7 +59,7 @@ export class DonutChartComponent implements OnChanges {
 
     const path = svg
       .selectAll('path')
-      .data(pie(this.values))
+      .data(pie(this.vals))
       .enter()
       .append('path')
       .attr('class', (d, i) => `DonutChart-section DonutChart-section--${i}`)

--- a/src/donut-chart.component.ts
+++ b/src/donut-chart.component.ts
@@ -20,11 +20,12 @@ import { Pie } from 'd3-shape';
 export class DonutChartComponent
   implements OnInit, OnChanges, AfterViewChecked {
   private vals: Array<number>;
-  private chart;
   private calculatedHeight: number;
   private calculatedWidth: number;
   private ht: string;
   private wd: string;
+  private outerRadius: number;
+  private innerRadius: number;
 
   @Input()
   get values(): Array<number> | number {
@@ -42,9 +43,9 @@ export class DonutChartComponent
       this.vals = this.vals.concat(100 - value);
     }
   }
-  @Input() outerRadius: number;
-  @Input() innerRadius: number;
+
   @Input() colors: Array<string> = d3.schemeCategory20;
+  @Input() innerWidth: string;
 
   /**
    * Height of the component in px or %.  Defaults to 100% if no height is specified.
@@ -82,7 +83,12 @@ export class DonutChartComponent
 
   ngOnChanges() {
     this.calculateDimensions();
-    this.innerRadius = this.outerRadius / 5 * 4;
+    if (!this.innerWidth) {
+      this.innerWidth = '80';
+    }
+    this.innerRadius = this.outerRadius * (parseFloat(this.innerWidth) / 100);
+    this.clearChart();
+    this.createDonutChart();
   }
 
   ngAfterViewChecked() {
@@ -123,5 +129,9 @@ export class DonutChartComponent
       .attr('class', (d, i) => `DonutChart-section DonutChart-section--${i}`)
       .attr('fill', (d, i) => this.colors[i % this.colors.length])
       .attr('d', arc);
+  }
+
+  private clearChart() {
+    d3.select(this.elementRef.nativeElement).selectAll('g').remove();
   }
 }

--- a/src/donut-chart.component.ts
+++ b/src/donut-chart.component.ts
@@ -1,4 +1,6 @@
-import { Component, Input, ElementRef, OnChanges, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component, Input, ElementRef, OnChanges, ChangeDetectionStrategy, OnInit, HostBinding, AfterViewChecked, AfterViewInit
+} from '@angular/core';
 import * as d3 from 'd3';
 import { Pie } from 'd3-shape';
 
@@ -8,8 +10,14 @@ import { Pie } from 'd3-shape';
   styleUrls: ['./donut-chart.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DonutChartComponent implements OnChanges {
+export class DonutChartComponent implements OnInit, OnChanges, AfterViewChecked {
   private vals: Array<number>;
+  private chart;
+  private calculatedHeight: number;
+  private calculatedWidth: number;
+  private ht: string;
+  private wd: string;
+
   @Input()
   get values(): Array<number> | number {
     return this.vals;
@@ -30,15 +38,54 @@ export class DonutChartComponent implements OnChanges {
   @Input() innerRadius: number;
   @Input() colors: Array<string> = d3.schemeCategory20;
 
+  /**
+   * Height of the component in px or %.  Defaults to 100% if no height is specified.
+   * @returns {string}
+   */
+  @Input()
+  @HostBinding('style.height')
+  get height(): string {
+    return this.ht ? this.ht : '100%';
+  }
+  set height(ht: string) {
+    this.ht = ht;
+  }
+
+  /**
+   * Width of the component in px or %.  Defaults to 100% if no width is specified.
+   * @returns {string}
+   */
+  @Input()
+  @HostBinding('style.width')
+  get width(): string {
+    return this.wd ? this.wd : '100%';
+  }
+  set width(wd: string) {
+    this.wd = wd;
+  }
+
+  @HostBinding('class.DonutChart') true;
+
   constructor(private elementRef: ElementRef) {}
 
-  ngOnChanges() {
-    this.elementRef.nativeElement.style.width = `${this.outerRadius * 2}px`;
-    this.elementRef.nativeElement.style.height = `${this.outerRadius * 2}px`;
-    this.elementRef.nativeElement.style.fontSize = `${this.outerRadius /
-      1.5}px`;
-    this.elementRef.nativeElement.classList.add('DonutChart');
+  public ngOnInit() {
     this.createDonutChart();
+  }
+
+  ngOnChanges() {
+    this.calculateDimensions();
+    this.innerRadius = (this.outerRadius / 5) * 4;
+  }
+
+  ngAfterViewChecked() {
+    this.calculateDimensions();
+    this.elementRef.nativeElement.style.fontSize = `${this.outerRadius / 1.5}px`;
+  }
+
+  private calculateDimensions() {
+    this.calculatedHeight = this.elementRef.nativeElement.getBoundingClientRect().height;
+    this.calculatedWidth = this.elementRef.nativeElement.getBoundingClientRect().width;
+    this.outerRadius = Math.min(this.calculatedWidth, this.calculatedHeight) / 2;
   }
 
   createDonutChart() {
@@ -49,13 +96,14 @@ export class DonutChartComponent implements OnChanges {
       .innerRadius(this.innerRadius)
       .outerRadius(this.outerRadius);
 
+    const side = Math.min(this.calculatedWidth, this.calculatedHeight);
     const svg = d3
       .select(this.elementRef.nativeElement)
-      .append('svg')
-      .attr('width', this.outerRadius * 2)
-      .attr('height', this.outerRadius * 2)
+      .selectAll('svg')
+      .attr('viewBox', `0 0 ${side} ${side}`)
       .append('g')
-      .attr('transform', `translate(${this.outerRadius},${this.outerRadius})`);
+      .attr('class', 'donut')
+      .attr('transform', `translate(${side / 2}, ${side / 2})`);
 
     const path = svg
       .selectAll('path')

--- a/src/donut-chart.component.ts
+++ b/src/donut-chart.component.ts
@@ -5,8 +5,7 @@ import {
   OnChanges,
   ChangeDetectionStrategy,
   OnInit,
-  HostBinding,
-  AfterViewChecked
+  HostBinding
 } from '@angular/core';
 import * as d3 from 'd3';
 import { Pie } from 'd3-shape';
@@ -18,15 +17,10 @@ import { Pie } from 'd3-shape';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DonutChartComponent
-  implements OnInit, OnChanges, AfterViewChecked {
+  implements OnInit, OnChanges {
+  private static readonly outerRadius = 50;
   private vals: Array<number>;
-  private calculatedHeight: number;
-  private calculatedWidth: number;
-  private ht: string;
-  private wd: string;
-  private outerRadius: number;
-  private innerRadius: number;
-  private innerWd: string;
+  private thickness: number;
 
   @Input()
   get values(): Array<number> | number {
@@ -48,40 +42,14 @@ export class DonutChartComponent
   @Input() colors: Array<string> = d3.schemeCategory20;
 
   /**
-   * The width of the donut hole.  Defaults to 80% if no value is specified.
+   * The thickness of the donut.  Defaults to 20% if no value is specified.
    */
   @Input()
-  get innerWidth(): string {
-    return this.innerWd ? this.innerWd : '80%';
+  get thicknessPct(): number {
+    return this.thickness ? this.thickness / 2 : 10;
   }
-  set innerWidth(innerWd: string) {
-    this.innerWd = innerWd;
-  }
-
-  /**
-   * Height of the component in px or %.  Defaults to 100% if no height is specified.
-   * @returns {string}
-   */
-  @Input()
-  @HostBinding('style.height')
-  get height(): string {
-    return this.ht ? this.ht : '100%';
-  }
-  set height(ht: string) {
-    this.ht = ht;
-  }
-
-  /**
-   * Width of the component in px or %.  Defaults to 100% if no width is specified.
-   * @returns {string}
-   */
-  @Input()
-  @HostBinding('style.width')
-  get width(): string {
-    return this.wd ? this.wd : '100%';
-  }
-  set width(wd: string) {
-    this.wd = wd;
+  set thicknessPct(thickness: number) {
+    this.thickness = thickness;
   }
 
   @HostBinding('class.DonutChart') true;
@@ -93,23 +61,8 @@ export class DonutChartComponent
   }
 
   ngOnChanges() {
-    this.calculateDimensions();
-    this.innerRadius = this.outerRadius * (parseFloat(this.innerWidth) / 100);
     this.clearChart();
     this.createDonutChart();
-  }
-
-  ngAfterViewChecked() {
-    this.calculateDimensions();
-    this.elementRef.nativeElement.style.fontSize = `${this.outerRadius /
-      1.5}px`;
-  }
-
-  private calculateDimensions() {
-    this.calculatedHeight = this.elementRef.nativeElement.getBoundingClientRect().height;
-    this.calculatedWidth = this.elementRef.nativeElement.getBoundingClientRect().width;
-    this.outerRadius =
-      Math.min(this.calculatedWidth, this.calculatedHeight) / 2;
   }
 
   createDonutChart() {
@@ -117,17 +70,16 @@ export class DonutChartComponent
 
     const arc: any = d3
       .arc()
-      .innerRadius(this.innerRadius)
-      .outerRadius(this.outerRadius);
+      .innerRadius(DonutChartComponent.outerRadius - this.thicknessPct)
+      .outerRadius(DonutChartComponent.outerRadius);
 
-    const side = Math.min(this.calculatedWidth, this.calculatedHeight);
     const svg = d3
       .select(this.elementRef.nativeElement)
       .selectAll('svg')
-      .attr('viewBox', `0 0 ${side} ${side}`)
+      .attr('viewBox', '0 0 100 100')
       .append('g')
       .attr('class', 'donut')
-      .attr('transform', `translate(${side / 2}, ${side / 2})`);
+      .attr('transform', 'translate(50, 50)');
 
     const path = svg
       .selectAll('path')


### PR DESCRIPTION
Story: https://jira.inbcu.com/browse/AUG-655
1. Fixed typescript errors on integration.
2. Removed label.  Now you can add text or other components as the inner html of the component: 
```<supre-donut-chart>50%</supre-donut-chart>```
3. Instead of setting the inner and outer radius, you set the width and height (px or %).  If you don't set a width and height, the component defaults to 100% for each (responsive):


```<supre-donut-chart [values]="[80]" [height]="'100px'" [width]="'100px'">80%</supre-donut-chart>```